### PR TITLE
Add email verification (double opt-in) before activating dating links

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,13 +14,15 @@ datasource db {
 }
 
 model AppointmentLink {
-  id             String        @id @default(cuid())
-  senderName     String
-  senderMail     String
-  dateName       String
-  createdAt      DateTime      @default(now())
-  appointments   Appointment[]
-  locations      Location[]    
+  id                String        @id @default(cuid())
+  senderName        String
+  senderMail        String
+  dateName          String
+  createdAt         DateTime      @default(now())
+  verified          Boolean       @default(false)
+  verificationToken String        @unique @default(cuid())
+  appointments      Appointment[]
+  locations         Location[]
 
 }
 

--- a/src/app/api/generate-link/route.js
+++ b/src/app/api/generate-link/route.js
@@ -1,5 +1,6 @@
 import { PrismaClient } from "@prisma/client";
 import { NextResponse } from "next/server";
+import { sendNotification } from "@/lib/mailer";
 
 const prisma = new PrismaClient();
 
@@ -25,19 +26,27 @@ export async function POST(request) {
         senderName,
         senderMail,
         dateName,
+        verified: false,
         locations: {
           create: locations.map((loc) => ({ name: loc })),
         },
       },
     });
 
-    const fullLink = `${process.env.NEXT_PUBLIC_URL}/r/${newLink.id}`;
+    const verifyUrl = `${process.env.NEXT_PUBLIC_URL}/api/verify/${newLink.verificationToken}`;
+
+    await sendNotification(
+      senderMail,
+      `Confirme ton adresse email pour activer ton lien DYWGODWM.\n\nClique ici : ${verifyUrl}`,
+      "Confirme ton email - DYWGODWM",
+      `<p>Confirme ton adresse email pour activer ton lien DYWGODWM.</p>
+       <p><a href="${verifyUrl}" style="display:inline-block;padding:12px 24px;background:#dc0011;color:#fff;border-radius:9999px;text-decoration:none;font-weight:600;">Confirmer mon email</a></p>`
+    );
 
     return new Response(
       JSON.stringify({
-        message: "Lien généré avec succès",
-        linkId: newLink.id,
-        linkUrl: fullLink,
+        message: "Un email de vérification a été envoyé",
+        pendingVerification: true,
       }),
       { status: 201 }
     );

--- a/src/app/api/verify/[token]/route.js
+++ b/src/app/api/verify/[token]/route.js
@@ -1,0 +1,45 @@
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+
+export async function GET(request, { params }) {
+  const { token } = await params;
+
+  if (!token) {
+    return new Response(JSON.stringify({ message: "Token manquant" }), {
+      status: 400,
+    });
+  }
+
+  try {
+    const link = await prisma.appointmentLink.findUnique({
+      where: { verificationToken: token },
+    });
+
+    if (!link) {
+      return new Response(JSON.stringify({ message: "Token invalide" }), {
+        status: 404,
+      });
+    }
+
+    if (link.verified) {
+      return Response.redirect(
+        `${process.env.NEXT_PUBLIC_URL}/verified/${link.id}`
+      );
+    }
+
+    await prisma.appointmentLink.update({
+      where: { id: link.id },
+      data: { verified: true },
+    });
+
+    return Response.redirect(
+      `${process.env.NEXT_PUBLIC_URL}/verified/${link.id}`
+    );
+  } catch (error) {
+    console.error(error);
+    return new Response(JSON.stringify({ message: "Erreur serveur" }), {
+      status: 500,
+    });
+  }
+}

--- a/src/app/generate/page.js
+++ b/src/app/generate/page.js
@@ -15,7 +15,6 @@ export default function LinkGenerator() {
   const [locations, setLocations] = useState([]);
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
-  const [isCopied, setIsCopied] = useState(false);
 
   const handleAddLocation = () => {
     const trimmed = newLocation.trim();
@@ -55,26 +54,15 @@ export default function LinkGenerator() {
       );
 
       setResult(res.data);
-      if (res.data) {
-        setResult(res.data);
-        setForm({ senderName: "", senderMail: "", dateName: "" });
-        setNewLocation("");
-        setLocations([]);
-      }
+      setForm({ senderName: "", senderMail: "", dateName: "" });
+      setNewLocation("");
+      setLocations([]);
     } catch (error) {
       console.error("Erreur lors de la génération :", error);
       alert(error.response?.data?.message || "Erreur lors de la génération");
     } finally {
       setLoading(false);
     }
-  };
-
-  const handleCopy = () => {
-    navigator.clipboard.writeText(result.linkUrl);
-    setIsCopied(true);
-    setTimeout(() => {
-      setIsCopied(false);
-    }, 2000);
   };
 
   return (
@@ -166,15 +154,11 @@ export default function LinkGenerator() {
           {loading ? "Creating your link..." : "Validate"}
         </Button>
       </form>
-      {result && (
+      {result?.pendingVerification && (
         <div className="mt-6 text-center max-w-md mx-auto break-words">
-          <Button
-            variant="fancy"
-            className="cursor-pointer"
-            onClick={() => handleCopy()}
-          >
-            {isCopied ? "Link copied" : "Copy the link"}{" "}
-          </Button>
+          <p className="text-lg font-semibold">
+            Check your email inbox to verify your address and activate the link.
+          </p>
         </div>
       )}
     </div>

--- a/src/app/r/[id]/page.js
+++ b/src/app/r/[id]/page.js
@@ -48,12 +48,17 @@ export default function DateGame() {
   }, [step]);
 
   useEffect(() => {
-    const fetchLocations = async () => {
+    const fetchLinkData = async () => {
       try {
         const response = await axios.get(
           `${process.env.NEXT_PUBLIC_URL}/api/link/${params.id}`
         );
         const linkData = response.data;
+
+        if (!linkData.verified) {
+          setStep("invalid");
+          return;
+        }
 
         const fetchedLocations =
           linkData.locations?.map((loc) => loc.name) || [];
@@ -65,11 +70,11 @@ export default function DateGame() {
         }
       } catch (error) {
         console.error("Erreur lors du chargement des lieux :", error);
-        setLocations(["Parc", "Terrasse", "Rooftop", "Café"]);
+        setStep("invalid");
       }
     };
 
-    fetchLocations();
+    fetchLinkData();
   }, [params.id]);
 
   const handleValidate = async () => {
@@ -169,6 +174,15 @@ export default function DateGame() {
     </div>
   );
 
+  const renderInvalid = () => (
+    <div className="text-center space-y-4">
+      <h1 className="text-4xl font-champ font-bold">
+        This link is not available
+      </h1>
+      <p className="text-lg">It may have expired or hasn&apos;t been verified yet.</p>
+    </div>
+  );
+
   return (
     <div className="min-h-screen max-w-screen flex items-center justify-center">
       {step === "home"
@@ -177,6 +191,8 @@ export default function DateGame() {
         ? renderCongrats()
         : step === "select"
         ? renderSelect()
+        : step === "invalid"
+        ? renderInvalid()
         : null}
     </div>
   );

--- a/src/app/verified/[id]/page.js
+++ b/src/app/verified/[id]/page.js
@@ -1,0 +1,36 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { useParams } from "next/navigation";
+import { useState } from "react";
+
+export default function VerifiedPage() {
+  const { id } = useParams();
+  const [isCopied, setIsCopied] = useState(false);
+
+  const linkUrl = `${process.env.NEXT_PUBLIC_URL}/r/${id}`;
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(linkUrl);
+    setIsCopied(true);
+    setTimeout(() => setIsCopied(false), 2000);
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center text-center max-w-md px-4">
+      <h1 className="font-champ text-5xl font-semibold mb-4">
+        Email verified!
+      </h1>
+      <p className="text-lg mb-6">
+        Your link is now active. Share it with your date!
+      </p>
+      <Button
+        variant="fancy"
+        className="cursor-pointer"
+        onClick={handleCopy}
+      >
+        {isCopied ? "Link copied!" : "Copy the link"}
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/mailer.js
+++ b/src/lib/mailer.js
@@ -17,14 +17,19 @@ transporter.verify().catch((err) => {
 /**
  * Envoie un email de notification.
  * Usage interne uniquement — pas exposé comme route API.
+ *
+ * @param {string} to - Adresse email du destinataire
+ * @param {string} text - Contenu texte brut
+ * @param {string} [subject] - Sujet de l'email
+ * @param {string} [html] - Contenu HTML (fallback: texte échappé)
  */
-export async function sendNotification(to, text) {
+export async function sendNotification(to, text, subject, html) {
   const info = await transporter.sendMail({
     from: `"DYWGODWM" <${process.env.SMTP_SERVER_USERNAME}>`,
     to,
-    subject: "Notification de DYWGODWM",
+    subject: subject || "Notification de DYWGODWM",
     text,
-    html: `<p>${text.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</p>`,
+    html: html || `<p>${text.replace(/</g, "&lt;").replace(/>/g, "&gt;")}</p>`,
   });
 
   return { messageId: info.messageId, envelope: info.envelope };


### PR DESCRIPTION
Links are now created as unverified. A confirmation email is sent to
the sender, who must click a verification link to activate it. The
/r/[id] page blocks access to unverified links, and the /generate page
shows a "check your inbox" message instead of immediately providing
the shareable link. After verification, users land on /verified/[id]
where they can copy the link.

https://claude.ai/code/session_01D5scpXLLZJtPKgnZBsCYvk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email verification for appointment link generation. Users now receive a verification email and must confirm before the link becomes active.
  * Added a shareable link retrieval page after verification with copy-to-clipboard functionality.

* **Bug Fixes**
  * Unverified appointment links are now blocked from being used.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->